### PR TITLE
feat!: add support for markdown sources

### DIFF
--- a/src/Rss.elm
+++ b/src/Rss.elm
@@ -67,6 +67,7 @@ type alias Item =
             , mimeType : String
             , bytes : Maybe Int
             }
+    , markdownContent : Maybe String
 
     {-
        TODO consider adding these
@@ -146,6 +147,7 @@ itemXml siteUrl item =
                  ]
                     ++ List.map encodeCategory item.categories
                     ++ ([ item.content |> Maybe.map (\content -> keyValue "content" content)
+                        , item.markdownContent |> Maybe.map (\content -> keyValue "source:markdown" content)
                         , item.contentEncoded |> Maybe.map (\content -> object [ ( "content:encoded", Dict.empty, cdata content ) ])
                         , item.enclosure |> Maybe.map encodeEnclosure
 

--- a/src/Rss.elm
+++ b/src/Rss.elm
@@ -117,7 +117,7 @@ generate feed =
                       , keyValue "description" feed.description
                       , keyValue "link" feed.url
 
-                      --<atom:link href="http://dallas.example.com/rss.xml" rel="self" type="application/rss+xml" />
+                      -- <atom:link href="http://dallas.example.com/rss.xml" rel="self" type="application/rss+xml" />
                       , keyValue "lastBuildDate" <| Imf.DateTime.fromPosix Time.utc feed.lastBuildTime
                       ]
                     , [ feed.generator |> Maybe.map (keyValue "generator") ] |> List.filterMap identity
@@ -149,7 +149,7 @@ itemXml siteUrl item =
                         , item.contentEncoded |> Maybe.map (\content -> object [ ( "content:encoded", Dict.empty, cdata content ) ])
                         , item.enclosure |> Maybe.map encodeEnclosure
 
-                        --<enclosure url="https://example.com/image.jpg" length="0" type="image/jpeg"/>
+                        -- <enclosure url="https://example.com/image.jpg" length="0" type="image/jpeg"/>
                         ]
                             |> List.filterMap identity
                        )

--- a/tests/RssTests.elm
+++ b/tests/RssTests.elm
@@ -27,6 +27,7 @@ suite =
                           , content = Nothing
                           , contentEncoded = Nothing
                           , enclosure = Nothing
+                          , markdownContent = Nothing
                           }
                         ]
                     , siteUrl = "https://elm-pages.com"
@@ -73,6 +74,7 @@ suite =
                                     , mimeType = "image/jpeg"
                                     , bytes = Nothing
                                     }
+                          , markdownContent = Just "# Hello!\\n\\nSome feed readers will render this, somehow <tb>"
                           }
                         ]
                     , siteUrl = "https://elm-pages.com"
@@ -91,6 +93,7 @@ suite =
 <link>https://elm-pages.com/blog/generate-files</link>
 <guid>https://elm-pages.com/blog/generate-files</guid>
 <pubDate>Fri, 05 Jun 2020 04:09:26 +0000</pubDate>
+<source:markdown># Hello!\\n\\nSome feed readers will render this, somehow &lt;tb&gt;</source:markdown>
 <content:encoded><![CDATA[<h1>Hello!</h1><p>Some feed readers will render this as HTML</p>]]></content:encoded>
 <enclosure length="0" type="image/jpeg" url="https://example.com/image.jpg"></enclosure>
 </item>
@@ -114,6 +117,7 @@ suite =
                           , content = Nothing
                           , contentEncoded = Just "<div>Simple HTML content</div>"
                           , enclosure = Nothing
+                          , markdownContent = Nothing
                           }
                         ]
                     , siteUrl = "https://example.com"


### PR DESCRIPTION
> > You could also add the rendered body, but this gets complicated because you don't have your CSS in the context of a feed reader, so you would likely want to render slightly differently.
> 
> I'm working on my own personal site rn and there's a decent chance I'll implement this myself (and if I do I'll be sure to backport it), but just FYI [it's](http://scripting.com/2022/07/19/152235.html?title=devNotesForMarkdownInRss) [possible](https://netnewswire.blog/2025/11/05/netnewswire-for-mac-and-ios.html) to include raw markdown in RSS feeds nowadays for RSS readers to render prettily. I've found it makes feeds like the Rust blogs much, much more readable.

_Originally posted by @lishaduck in https://github.com/kraklin/elm-pages-blog-starter/issues/14#issuecomment-3902438644_


---

I "learned to code" by listening to Elm radio, so I'd say this smells of the [builder pattern](https://elm-radio.com/episode/builder-pattern) b/c I shouldn't need to make a breaking change here, but do 🙃

Thanks for all of the years of entertainment & education ❤️